### PR TITLE
Templates refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Minimum CMake version required
 cmake_minimum_required(VERSION 3.20)
 
+set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel.")
+
 # Project information
 project(TestWutils CXX)
 
@@ -21,7 +23,9 @@ elseif(UNIX)
 endif()
 
 # Define the source files
-set(SOURCES wutils.cpp testwutils.cpp)
+set(TEST_SOURCES wutils.cpp testwutils.cpp)
+set(EXAMPLE_SOURCES wutils.cpp example.cpp)
 
 # Add executable target
-add_executable(testwutils ${SOURCES})
+add_executable(testwutils ${TEST_SOURCES})
+add_executable(example ${EXAMPLE_SOURCES})

--- a/README.md
+++ b/README.md
@@ -37,4 +37,6 @@ This can lead to incorrect behavior in certain edge cases. For example, some Win
 
 To use the library, simply add `wutils.hpp` and `wutils.cpp` to your project, and add them to your compilation steps.
 
-For building examples, see the examples `Makefile.exmample` (GNU Make) and `Makefile.vc.example` (MSVC nmake.exe)
+For code examples, see `example.cpp`.
+
+For building examples, see the `CMakeLists.txt` file, or example Makefiles `Makefile.exmample` (GNU Make) and `Makefile.vc.example` (MSVC nmake.exe)

--- a/example.cpp
+++ b/example.cpp
@@ -1,0 +1,40 @@
+#include <cassert>
+#include <string>
+#include <expected>
+#include "wutils.hpp"
+
+// Define functions that use "safe" UTF encoded string types
+void do_something(std::u8string u8s) { (void) u8s; }
+void do_something(std::u16string u16s) { (void) u16s; }
+void do_something(std::u32string u32s) { (void) u32s; }
+void do_something_u32(std::u32string u32s) { (void) u32s; }
+void do_something_w(std::wstring ws) { (void) ws; }
+
+int main() {
+    using wutils::ustring; // Type resolved at compile time based on sizeof(wchar), either std::u16string or std::32string
+    
+    std::wstring wstr = L"Hello, World";
+    ustring ustr = wutils::ws_to_us(wstr); // Convert to UTF string type
+    
+    do_something(ustr); // Call our "safe" function using the implementation-native UTF string equivalent type
+
+    // You can still convert it back to a wstring to use with other APIs
+    std::wstring w_out = wutils::us_to_ws(ustr);
+    do_something_w(w_out);
+    
+    // You can also do a checked conversion to specific UTF string types
+    // (see wutils.hpp for explanation of return type)
+    wutils::ConversionResult<std::u32string> conv = 
+    wutils::u32<wchar_t>(wstr, wutils::ErrorPolicy::SkipInvalidValues);
+    
+    if (conv) { 
+        do_something_u32(*conv);
+    }
+    
+    // Bonus, cross-platform wchar column width function, based on the "East Asian Width" property of unicode characters
+    assert(wutils::wswidth(L"中国人") == 6); // Chinese characters are 2-cols wide each
+    // Works with emojis too (each emoji is 2-cols wide), and emoji sequence modifiers
+    assert(wutils::wswidth(L"😂🌎👨‍👩‍👧‍👦") == 6);
+
+    return EXIT_SUCCESS;
+}

--- a/testwutils.cpp
+++ b/testwutils.cpp
@@ -10,7 +10,12 @@
 #include "wutils.hpp"
 #include "test.hpp"
 
-void test_case(std::wstring ws, const int expected) {
+template <typename U, typename V>
+void assert_equal(const U& a, const V& b) {
+    ASSERT_TRUE(a == b);
+}
+
+void test_width(std::wstring ws, const int expected) {
     int width = wutils::wswidth(ws);
     std::wstringstream wss; wss << L"Length of \"" << ws << L"\": " << width;
     wutils::wprintln(wss.str());
@@ -34,6 +39,20 @@ void test_case(std::wstring ws, const int expected) {
     ASSERT_EQ(expected, width);
 }
 
+template<typename FromChar, typename ToChar, typename Func>
+void test_conversion(Func func, std::basic_string_view<FromChar> in) {
+    wutils::ConversionResult<std::basic_string<ToChar>> result = func(in, wutils::ErrorPolicy::SkipInvalidValues);
+    ASSERT_TRUE(result);
+    auto w_in = wutils::ws<FromChar>(in);
+    ASSERT_TRUE(w_in);
+    auto w_out = wutils::ws<ToChar>(*result);
+    ASSERT_TRUE(w_out);
+
+    ASSERT_EQ(*w_in, *w_out);
+    std::wstringstream wss; wss << "Conversion successful: \"" << *w_in << L"\" == \"" << *w_out << L"\"";
+    wutils::wprintln(wss.str());
+}
+
 int main() {
     using wutils::uchar_t, wutils::ustring, wutils::ustring_view;
     // Initialize locale
@@ -46,58 +65,114 @@ int main() {
 
     // Test Case 1: Simple ASCII string
     {
-        test_case(L"Hello, World!", 13);
+        test_width(L"Hello, World!", 13);
         wutils::wprintln(L"Test 1 (ASCII): Passed\n-----");
     }
 
     // Test Case 2: Unicode character within the Basic Multilingual Plane (BMP)
     // The character 'é' (LATIN SMALL LETTER E WITH ACUTE) has code point U+00E9
     {
-        test_case(L"Résumé", 6);
+        test_width(L"Résumé", 6);
         wutils::wprintln(L"Test 2 (Unicode BMP): Passed\n-----");
     }
 
     // Test Case 3: Character requiring a surrogate pair (if wchar_t is 16 bits)
     // The character '😂' (FACE WITH TEARS OF JOY) has code point U+1F602
     {
-        test_case(L"😂😂😂", 6);
+        test_width(L"😂😂😂", 6);
         wutils::wprintln(L"Test 3 (Simple Emoji Surrogate Pair): Passed\n-----");
     }
     // Test Case 4: Empty string
     {
-        test_case(L"", 0);
+        test_width(L"", 0);
         wutils::wprintln(L"Test 4 (Empty String): Passed\n-----");
     }
     // Test Case 5: Advanced Emoji Sequence
     {
         // This single emoji (👩🏼‍🚀) is a set of 4 codepoints [128105] [127996] [8205] [128640]
-        test_case(L"👩🏼‍🚀", 2);
+        test_width(L"👩🏼‍🚀", 2);
         wutils::wprintln(L"Test 5 (Advanced Emoji Sequence): Passed\n-----");
     }
     // Test Case 6: Characters outside the Basic Multilingual Plane (Plane 0)
     {
         /* ===PLANE 1 (Supplementary Multilingual Plane)=== */
 
-        test_case(L"𐌀𐌍𐌓𐌀", 4); // Old Italic
-        test_case(L"𝕄𝕒𝕥𝕙𝕖𝕞𝕒𝕥𝕚𝕔𝕤", 11); // Mathematical Alpanumeric
-        test_case(L"🌍🌎🌏", 6); // Emoji 1
-        test_case(L"👨‍👩‍👧‍👦", 2); // Emoji 2
+        test_width(L"𐌀𐌍𐌓𐌀", 4); // Old Italic
+        test_width(L"𝕄𝕒𝕥𝕙𝕖𝕞𝕒𝕥𝕚𝕔𝕤", 11); // Mathematical Alpanumeric
+        test_width(L"🌍🌎🌏", 6); // Emoji 1
+        test_width(L"👨‍👩‍👧‍👦", 2); // Emoji 2
         wutils::wprintln(L"Test 6.1 (Supplementary Multilingual Plane): Passed\n-----");
 
         /* ===PLANE 2 (Supplementary Ideographic Plane)=== */
-        test_case(L"𠔻𠕋𠖊𠖍𠖐", 10); // Rare Chinese Characters
-        test_case(L"𠮷", 2); // Rare Japanese Variant
-        test_case(L"𠀤𠀧𠁀", 6); // Rare Chinese Variants
-        test_case(L"𠊛好", 4); // Vietnamese Chữ Nôm (CJK Extensions)
-        test_case(L"𪚥𪆷𪃹", 6); // Rare Japanese Kanji (CJK Extensions)
-        test_case(L"𪜈𪜋𪜌", 6); // Rare Korean Hanja (CJK Extensions)
+        test_width(L"𠔻𠕋𠖊𠖍𠖐", 10); // Rare Chinese Characters
+        test_width(L"𠮷", 2); // Rare Japanese Variant
+        test_width(L"𠀤𠀧𠁀", 6); // Rare Chinese Variants
+        test_width(L"𠊛好", 4); // Vietnamese Chữ Nôm (CJK Extensions)
+        test_width(L"𪚥𪆷𪃹", 6); // Rare Japanese Kanji (CJK Extensions)
+        test_width(L"𪜈𪜋𪜌", 6); // Rare Korean Hanja (CJK Extensions)
         wutils::wprintln(L"Test 6.2 (Supplementary Ideographic Plane): Passed\n-----");
 
     }
     // Test case 7: Arabic
     {
-        test_case(L"اَلْعَرَبِيَّةُ", 7);
+        test_width(L"اَلْعَرَبِيَّةُ", 7);
         wutils::wprintln(L"Test 7 (Arabic): Passed\n-----");
+    }
+
+    // Test conversions
+    {
+        std::wstring w_in = L"Hello, World!";
+        std::u8string u8_in = u8"Hello, World!";
+        std::u16string u16_in = u"Hello, World!";
+        std::u32string u32_in = U"Hello, World!";
+
+        ustring u_out = wutils::ws_to_us(w_in);
+        if constexpr (std::is_same_v<wutils::ustring, std::u8string>) {
+            assert_equal(u8_in, u_out);
+            wutils::wprintln(L"Assertion satisfied, u8_in == u_out");
+        } else if constexpr (std::is_same_v<wutils::ustring, std::u16string>) {
+            assert_equal(u16_in, u_out);
+            wutils::wprintln(L"Assertion satisfied, u16_in == u_out");
+        } else if constexpr (std::is_same_v<wutils::ustring, std::u32string>) {
+            assert_equal(u32_in, u_out);
+            wutils::wprintln(L"Assertion satisfied, u32_in == u_out");
+        }
+
+        // Wchar to ustrings
+        test_conversion<wchar_t, char8_t>(wutils::u8<wchar_t>, w_in);
+        test_conversion<wchar_t, char16_t>(wutils::u16<wchar_t>, w_in);
+        test_conversion<wchar_t, char32_t>(wutils::u32<wchar_t>, w_in);
+        test_conversion<wchar_t, uchar_t>(wutils::us<wchar_t>, w_in);
+
+        // Ustrings to wchar
+        test_conversion<char8_t, wchar_t>(wutils::ws<char8_t>, u8_in);
+        test_conversion<char16_t, wchar_t>(wutils::ws<char16_t>, u16_in);
+        test_conversion<char32_t, wchar_t>(wutils::ws<char32_t>, u32_in);
+        test_conversion<uchar_t, wchar_t>(wutils::ws<uchar_t>, u_out);
+
+        // Between ustrings
+        test_conversion<char8_t, char8_t>(wutils::u8<char8_t>, u8_in);
+        test_conversion<char16_t, char8_t>(wutils::u8<char16_t>, u16_in);
+        test_conversion<char32_t, char8_t>(wutils::u8<char32_t>, u32_in);
+        test_conversion<uchar_t, char8_t>(wutils::u8<uchar_t>, u_out);
+
+        test_conversion<char8_t, char16_t>(wutils::u16<char8_t>, u8_in);
+        test_conversion<char16_t, char16_t>(wutils::u16<char16_t>, u16_in);
+        test_conversion<char32_t, char16_t>(wutils::u16<char32_t>, u32_in);
+        test_conversion<uchar_t, char16_t>(wutils::u16<uchar_t>, u_out);
+
+        test_conversion<char8_t, char32_t>(wutils::u32<char8_t>, u8_in);
+        test_conversion<char16_t, char32_t>(wutils::u32<char16_t>, u16_in);
+        test_conversion<char32_t, char32_t>(wutils::u32<char32_t>, u32_in);
+        test_conversion<uchar_t, char32_t>(wutils::u32<uchar_t>, u_out);
+
+        test_conversion<char8_t, uchar_t>(wutils::us<char8_t>, u8_in);
+        test_conversion<char16_t, uchar_t>(wutils::us<char16_t>, u16_in);
+        test_conversion<char32_t, uchar_t>(wutils::us<char32_t>, u32_in);
+        test_conversion<uchar_t, uchar_t>(wutils::us<uchar_t>, u_out);
+
+        wutils::wprintln(L"All conversion tests passed!");
+
     }
 
     wutils::wprintln(L"All tests completed successfully!");

--- a/wutils.cpp
+++ b/wutils.cpp
@@ -78,7 +78,7 @@
 
 #include "wutils.hpp"
 
-namespace detail {
+namespace internal {
 
 struct interval {
   char32_t first;
@@ -289,10 +289,10 @@ int mk_wcswidth(const char32_t *pwcs, size_t n)
   return width;
 }
 
-} // namespace detail
+} // namespace internal
 
 int wutils::uswidth(const std::u32string_view u32s) {
-    return detail::mk_wcswidth(u32s.data(), u32s.size());
+    return internal::mk_wcswidth(u32s.data(), u32s.size());
 }
 
 int wutils::uswidth(const std::u16string_view u16s) {
@@ -300,9 +300,9 @@ int wutils::uswidth(const std::u16string_view u16s) {
     if (!u32s) {
         // Conversion failed, but compute anyways
         std::u32string_view partial_skipped_seq = u32s.error().partial_result;
-        return detail::mk_wcswidth(partial_skipped_seq.data(), partial_skipped_seq.size());
+        return internal::mk_wcswidth(partial_skipped_seq.data(), partial_skipped_seq.size());
     }
-    return detail::mk_wcswidth(u32s->data(), u32s->size());
+    return internal::mk_wcswidth(u32s->data(), u32s->size());
 }
 
 int wutils::uswidth(const std::u8string_view u8s) {
@@ -310,9 +310,9 @@ int wutils::uswidth(const std::u8string_view u8s) {
     if (!u32s) {
         // Conversion failed, but compute anyways
         std::u32string_view partial_skipped_seq = u32s.error().partial_result;
-        return detail::mk_wcswidth(partial_skipped_seq.data(), partial_skipped_seq.size());
+        return internal::mk_wcswidth(partial_skipped_seq.data(), partial_skipped_seq.size());
     }
-    return detail::mk_wcswidth(u32s->data(), u32s->size());
+    return internal::mk_wcswidth(u32s->data(), u32s->size());
 }
 
 #ifdef _WIN32
@@ -332,7 +332,7 @@ void wutils::wprintln(const std::wstring_view ws) {
 /* UTF conversion */ 
 
 // UTF-16 to UTF-8 conversion
-wutils::ConversionResult<std::u8string> wutils::u8(const std::u16string_view u16s, const ErrorPolicy errorPolicy) {
+wutils::ConversionResult<std::u8string> wutils::detail::u8(const std::u16string_view u16s, const ErrorPolicy errorPolicy) {
     bool is_valid = true;
     std::u8string result;
     result.reserve(u16s.size() * 3); // Rough estimate for space needed
@@ -391,7 +391,7 @@ wutils::ConversionResult<std::u8string> wutils::u8(const std::u16string_view u16
 }
 
 // UTF-32 to UTF-8 conversion
-wutils::ConversionResult<std::u8string> wutils::u8(const std::u32string_view u32s, const ErrorPolicy errorPolicy) {
+wutils::ConversionResult<std::u8string> wutils::detail::u8(const std::u32string_view u32s, const ErrorPolicy errorPolicy) {
     bool is_valid = true;
     std::u8string result;
     result.reserve(u32s.size() * 4); // Worst case scenario
@@ -434,7 +434,7 @@ wutils::ConversionResult<std::u8string> wutils::u8(const std::u32string_view u32
 }
 
 // UTF-8 to UTF-16 conversion
-wutils::ConversionResult<std::u16string> wutils::u16(const std::u8string_view u8s, const ErrorPolicy errorPolicy) {
+wutils::ConversionResult<std::u16string> wutils::detail::u16(const std::u8string_view u8s, const ErrorPolicy errorPolicy) {
     bool is_valid = true;
     std::u16string result;
     result.reserve(u8s.size()); // Initial capacity estimation
@@ -502,7 +502,7 @@ wutils::ConversionResult<std::u16string> wutils::u16(const std::u8string_view u8
 }
 
 // UTF-32 to UTF-16 conversion
-wutils::ConversionResult<std::u16string> wutils::u16(const std::u32string_view u32s, const ErrorPolicy errorPolicy) {
+wutils::ConversionResult<std::u16string> wutils::detail::u16(const std::u32string_view u32s, const ErrorPolicy errorPolicy) {
     bool is_valid = true;
     std::u16string result;
     result.reserve(u32s.size() * 2); // Some code points might need surrogate pairs
@@ -536,7 +536,7 @@ wutils::ConversionResult<std::u16string> wutils::u16(const std::u32string_view u
 }
 
 // UTF-8 to UTF-32 conversion
-wutils::ConversionResult<std::u32string> wutils::u32(const std::u8string_view u8s, const ErrorPolicy errorPolicy) {
+wutils::ConversionResult<std::u32string> wutils::detail::u32(const std::u8string_view u8s, const ErrorPolicy errorPolicy) {
     bool is_valid = true;
     std::u32string result;
     result.reserve(u8s.size()); // Initial capacity estimation
@@ -597,7 +597,7 @@ wutils::ConversionResult<std::u32string> wutils::u32(const std::u8string_view u8
 }
 
 // UTF-16 to UTF-32 conversion
-wutils::ConversionResult<std::u32string> wutils::u32(const std::u16string_view u16s, const ErrorPolicy errorPolicy) {
+wutils::ConversionResult<std::u32string> wutils::detail::u32(const std::u16string_view u16s, const ErrorPolicy errorPolicy) {
     bool is_valid = true;
     std::u32string result;
     result.reserve(u16s.size()); // Initial capacity

--- a/wutils.hpp
+++ b/wutils.hpp
@@ -12,53 +12,6 @@
 
 namespace wutils {
 
-// Determines course of action when encountered with an invalid sequence
-enum class ErrorPolicy {
-    SkipInvalidValues, // Skip invalid values and continue conversion to the best of its ability
-    StopOnFirstError // Stop conversion on the first invalid value, return partial conversion
-};
-
-template<typename T>
-struct ConversionFailure {
-    // Either the "best effort" result skipping invalid characters, 
-    // or the partially converted sequence up to the point of failure, depending on error policy
-    T partial_result; 
-};
-
-template<typename T>
-using ConversionResult = std::expected<T, ConversionFailure<T>>;
-
-inline ConversionResult<std::u8string> u8(const std::u8string_view u8s,
-    [[maybe_unused]] const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues) { 
-    return std::u8string(u8s); 
-}
-ConversionResult<std::u8string> u8(const std::u16string_view u16s, 
-    const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues);
-ConversionResult<std::u8string> u8(const std::u32string_view u32s, 
-    const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues);
-
-ConversionResult<std::u16string> u16(const std::u8string_view u8s, 
-    const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues);
-inline ConversionResult<std::u16string> u16(const std::u16string_view u16s,
-    [[maybe_unused]] const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues) {
-    return std::u16string(u16s);
-}
-ConversionResult<std::u16string> u16(const std::u32string_view u32s, 
-    const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues);
-
-ConversionResult<std::u32string> u32(const std::u8string_view u8s, 
-    const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues);
-ConversionResult<std::u32string> u32(const std::u16string_view u16s, 
-    const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues);
-inline ConversionResult<std::u32string> u32(const std::u32string_view u32s,
-    [[maybe_unused]] const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues) {
-    return std::u32string(u32s);
-}
-
-int uswidth(const std::u8string_view u8s);
-int uswidth(const std::u16string_view u16s);
-int uswidth(const std::u32string_view u32s);
-
 static constexpr bool wchar_is_char8 = sizeof(wchar_t) == sizeof(char8_t); // not used anywhere afaik but still here for completion
 static constexpr bool wchar_is_char16 = sizeof(wchar_t) == sizeof(char16_t); // used on Windows
 static constexpr bool wchar_is_char32 = sizeof(wchar_t) == sizeof(char32_t); // used on Linux, MacOS, and most UNIX systems
@@ -87,43 +40,6 @@ using ustring_view = std::basic_string_view<uchar_t>;
 // Final sanity check
 static_assert(sizeof(wchar_t) == sizeof(ustring::value_type) && sizeof(wchar_t) == sizeof(ustring_view::value_type), "Invalid wchar_t deduction");
 
-#ifdef _MSC_VER // MSVC-only optimization
-inline ustring us(const std::wstring_view ws) {
-    return ustring(std::from_range, ws);
-}
-
-inline std::wstring ws(const ustring_view us) {
-    return std::wstring(std::from_range, us);
-}
-
-inline std::u8string us(const std::string_view s) {
-    return std::u8string(std::from_range, s);
-}
-#else // General, standard-compliant implementation
-inline ustring us(std::wstring_view ws) {
-    return ws | std::ranges::views::transform([](wchar_t wc) {
-        return static_cast<uchar_t>(wc);
-    }) | std::ranges::to<ustring>();
-}
-
-inline std::wstring ws(const ustring_view us) {
-    return us | std::ranges::views::transform([](uchar_t uc) {
-        return static_cast<wchar_t>(uc);
-    }) | std::ranges::to<std::wstring>();
-}
-
-inline std::u8string us(const std::string_view s) {
-    return s | std::ranges::views::transform([](char c) {
-        return static_cast<char8_t>(c);
-    }) | std::ranges::to<std::u8string>();
-}
-#endif
-
-inline int wswidth(const std::wstring_view ws) {
-    ustring u = wutils::us(ws);
-    return wutils::uswidth(u);
-}
-
 // Windows sucks and can't properly print std::wcout to terminal so we use a wrapper
 #ifdef _WIN32
 void wprint(const std::wstring_view ws);
@@ -136,6 +52,203 @@ inline void wprintln(const std::wstring_view ws) {
     std::wcout << ws << std::endl;
 }
 #endif
+
+// Determines course of action when encountered with an invalid sequence
+enum class ErrorPolicy {
+    SkipInvalidValues, // Skip invalid values and continue conversion to the best of its ability
+    StopOnFirstError // Stop conversion on the first invalid value, return partial conversion
+};
+
+template<typename T>
+struct ConversionFailure {
+    // Either the "best effort" result skipping invalid characters, 
+    // or the partially converted sequence up to the point of failure, depending on error policy
+    T partial_result; 
+};
+
+template<typename T>
+using ConversionResult = std::expected<T, ConversionFailure<T>>;
+
+namespace detail {
+
+template<typename FromChar, typename ToChar>
+struct IsImplicitlyConvertible {
+    static constexpr bool value = false;
+};
+
+template<>
+struct IsImplicitlyConvertible<char, char8_t> {
+    static constexpr bool value = true;
+};
+
+template<>
+struct IsImplicitlyConvertible<char8_t, char> {
+    static constexpr bool value = true;
+};
+
+template<>
+struct IsImplicitlyConvertible<wchar_t, uchar_t> {
+    static constexpr bool value = true;
+};
+
+template<>
+struct IsImplicitlyConvertible<uchar_t, wchar_t> {
+    static constexpr bool value = true;
+};
+
+inline ConversionResult<std::u8string> u8(const std::u8string_view u8s,
+    [[maybe_unused]] const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues) {
+    return std::u8string(u8s);
+}
+ConversionResult<std::u8string> u8(const std::u16string_view u16s, 
+    const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues);
+ConversionResult<std::u8string> u8(const std::u32string_view u32s, 
+    const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues);
+
+ConversionResult<std::u16string> u16(const std::u8string_view u8s, 
+    const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues);
+inline ConversionResult<std::u16string> u16(const std::u16string_view u16s,
+    [[maybe_unused]] const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues) {
+    return std::u16string(u16s);
+}
+ConversionResult<std::u16string> u16(const std::u32string_view u32s, 
+    const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues);
+
+ConversionResult<std::u32string> u32(const std::u8string_view u8s, 
+    const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues);
+ConversionResult<std::u32string> u32(const std::u16string_view u16s, 
+    const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues);
+inline ConversionResult<std::u32string> u32(const std::u32string_view u32s,
+    [[maybe_unused]] const ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues) {
+    return std::u32string(u32s);
+}
+
+template<typename FromChar, typename ToChar>
+requires IsImplicitlyConvertible<FromChar, ToChar>::value
+std::basic_string<ToChar> convertImplicitly(std::basic_string_view<FromChar> from) {
+#ifdef _MSC_VER // MSVC specific optimization
+         return std::basic_string<ToChar>(std::from_range, from);
+#else // Generic conversion
+        return from | std::ranges::views::transform([](FromChar wc) {
+            return static_cast<ToChar>(wc);
+        }) | std::ranges::to<std::basic_string<ToChar>>();
+#endif
+};
+
+template<typename FromChar>
+ConversionResult<ustring> convert_to_ustring(std::basic_string_view<FromChar> from, ErrorPolicy errorPolicy) {
+    if constexpr (std::is_same_v<uchar_t, char8_t>) {
+        return u8(from, errorPolicy);
+    } else if constexpr (std::is_same_v<uchar_t, char16_t>) {
+        return u16(from, errorPolicy);
+    } else if constexpr (std::is_same_v<uchar_t, char32_t>) {
+        return u32(from, errorPolicy);
+    }
+}
+
+template<typename ToChar>
+ConversionResult<std::basic_string<ToChar>> convert_from_ustring(ustring_view from, ErrorPolicy errorPolicy) {
+    if constexpr (std::is_same_v<ToChar, char8_t>) {
+        return u8(from, errorPolicy);
+    } else if constexpr (std::is_same_v<ToChar, char16_t>) {
+        return u16(from, errorPolicy);
+    } else if constexpr (std::is_same_v<ToChar, char32_t>) {
+        return u32(from, errorPolicy);
+    } else if constexpr (std::is_same_v<ToChar, wchar_t>) {
+        return convertImplicitly<uchar_t, wchar_t>(from);
+    }
+}
+
+template<typename ToChar>
+ConversionResult<std::basic_string<ToChar>> propagateError(ConversionResult<ustring> inner, ErrorPolicy errorPolicy) {
+    if (inner.has_value()) {
+        return convert_from_ustring<ToChar>(*inner, errorPolicy);
+    } else {
+        ConversionResult<std::basic_string<ToChar>> last = convert_from_ustring<ToChar>(inner.error().partial_result, errorPolicy);
+        std::basic_string failedError = ( (last) ? (*last) : (last.error().partial_result));
+        return std::unexpected(ConversionFailure<std::basic_string<ToChar>>(failedError));
+    }
+}
+
+
+} // namespace detail
+// Main "dispatcher"-like convert template
+// It works like this because it needs to handle cases where we need an intermediate conversion to uchar_t
+// E.g to convert wchar_t to char32_t on a Windows system (where uchar_t = char16_t), we need to:
+// 1. Convert wchar_t to char16_t using convertImplicitly
+// 2. Convert char16_t to char32_t using detail::u32(u16string_view)
+// Same thing happens in the opposite direction (char32_t to wchar_t)
+template<typename FromChar, typename ToChar>
+ConversionResult<std::basic_string<ToChar>> convert(std::basic_string_view<FromChar> from, 
+        ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues) {
+    if constexpr (std::is_same_v<FromChar, ToChar>) {
+        return std::basic_string<ToChar>(from);
+    }
+    else if constexpr (detail::IsImplicitlyConvertible<FromChar, ToChar>::value) {
+        return detail::convertImplicitly<FromChar, ToChar>(from);
+    } else if constexpr (std::is_same_v<ToChar, char8_t>) {
+        return detail::propagateError<char8_t>(detail::convert_to_ustring<FromChar>(from, errorPolicy), errorPolicy);
+    } else if constexpr (std::is_same_v<ToChar, char16_t>) {
+        return detail::propagateError<char16_t>(detail::convert_to_ustring<FromChar>(from, errorPolicy), errorPolicy);
+    } else if constexpr (std::is_same_v<ToChar, char32_t>) {
+        return detail::propagateError<char32_t>(detail::convert_to_ustring<FromChar>(from, errorPolicy), errorPolicy);
+    } else if constexpr (std::is_same_v<ToChar, wchar_t>) {
+        return detail::propagateError<wchar_t>(detail::convert_to_ustring<FromChar>(from, errorPolicy), errorPolicy);
+    }
+}
+
+// Simple conversions to avoid ConversionResult
+inline ustring ws_to_us(std::wstring_view from) {
+    return detail::convertImplicitly<wchar_t, uchar_t>(from);
+}
+
+inline std::wstring us_to_ws(ustring_view from) {
+    return detail::convertImplicitly<uchar_t, wchar_t>(from);
+}
+
+inline std::u8string s_to_u8s(std::string_view from) {
+    return detail::convertImplicitly<char, char8_t>(from);
+}
+
+inline std::string u8s_to_s(std::u8string_view from) {
+    return detail::convertImplicitly<char8_t, char>(from);
+}
+
+// "Advanced" conversions that require ConversionResult
+template<typename FromChar>
+inline ConversionResult<std::u8string> u8(std::basic_string_view<FromChar> from, ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues) {
+    return convert<FromChar, char8_t>(from, errorPolicy);
+}
+
+template<typename FromChar>
+inline ConversionResult<std::u16string> u16(std::basic_string_view<FromChar> from, ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues) {
+    return convert<FromChar, char16_t>(from, errorPolicy);
+}
+
+template<typename FromChar>
+inline ConversionResult<std::u32string> u32(std::basic_string_view<FromChar> from, ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues) {
+    return convert<FromChar, char32_t>(from, errorPolicy);
+}
+
+template<typename FromChar>
+inline ConversionResult<ustring> us(std::basic_string_view<FromChar> from, ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues) {
+    return convert<FromChar, uchar_t>(from, errorPolicy);
+}
+
+template<typename FromChar>
+inline ConversionResult<std::wstring> ws(std::basic_string_view<FromChar> from, ErrorPolicy errorPolicy = ErrorPolicy::SkipInvalidValues) {
+    return convert<FromChar, wchar_t>(from, errorPolicy);
+}
+
+int uswidth(const std::u8string_view u8s);
+int uswidth(const std::u16string_view u16s);
+int uswidth(const std::u32string_view u32s);
+
+inline int wswidth(const std::wstring_view ws) {
+    ustring u = wutils::ws_to_us(ws);
+    return wutils::uswidth(u);
+}
+
 
 } // namespace wutils
 


### PR DESCRIPTION
Add a "dispatch-like" convert template, which helps convert any wstring/ustring to any other, instead of just the directly implemented conversions